### PR TITLE
chore: update .desktop files to be compatible with kde 6

### DIFF
--- a/src/kim_compressandresize.desktop.in
+++ b/src/kim_compressandresize.desktop.in
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2005, 2006  Charles Bouveyron <charles.bouveyron@free.fr>
 # Copyright (C) 2025  Tomáš Hnyk <tomashnyk@gmail.com>
+# Copyright (C) 2025  Miguel Useche <migueluseche@skatox.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +20,6 @@
 [Desktop Entry]
 Type=Service
 MimeType=image/*;
-ServiceTypes=KonqPopupMenu/Plugin
 Actions=aRcprs10;bRcprs20;cRcprs30;dRcprs40;eRcprs50;fRcprs60;gRcprs70;hRcprs80;iRcprs90;jRcprsCustom;_SEPARATOR_;aRsize0300;bRsize0600;cRsize0800;dRsize1024;eRsize1280;fRsize1400;gRsize1600;hRsize1920;iRsize2560;jRsize3440;kRsize3840;lRsizeCustom;_SEPARATOR_;aWebThumb75120;bWebExp75640;cWebExp75800;dWebExp751024;
 Encoding=UTF-8
 _X-KDE-Submenu=Kim — Compress and Resize

--- a/src/kim_compressandresizevideo.desktop.in
+++ b/src/kim_compressandresizevideo.desktop.in
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2005, 2006  Charles Bouveyron <charles.bouveyron@free.fr>
 # Copyright (C) 2025  Tomáš Hnyk <tomashnyk@gmail.com>
+# Copyright (C) 2025  Miguel Useche <migueluseche@skatox.com>
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +19,7 @@
 
 [Desktop Entry]
 Type=Service
-ServiceTypes=KonqPopupMenu/Plugin,video/*
+MimeType=video/*;
 Actions=ResizeVideo1280_17_265;ResizeVideo1280_23_265;ResizeVideo1280_29_265;ResizeVideo1280_17_264;ResizeVideo1280_23_264;ResizeVideo1280_29_264;_SEPARATOR_;ResizeVideo1920_17_265;ResizeVideo1920_23_265;ResizeVideo1920_29_265;ResizeVideo1920_17_264;ResizeVideo1920_23_264;ResizeVideo1920_29_264
 Encoding=UTF-8
 _X-KDE-Submenu=Kim — Compress and Resize

--- a/src/kim_convertandrotate.desktop.in
+++ b/src/kim_convertandrotate.desktop.in
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2005, 2006  Charles Bouveyron <charles.bouveyron@free.fr>
 # Copyright (C) 2025  Tomáš Hnyk <tomashnyk@gmail.com>
+# Copyright (C) 2025  Miguel Useche <migueluseche@skatox.com>
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +19,7 @@
 
 [Desktop Entry]
 Type=Service
-ServiceTypes=KonqPopupMenu/Plugin,image/*
+MimeType=image/*;
 Actions=JPEG;PNG;GIF;TIFF;PDF;ConvCustom;_SEPARATOR_;GrayScale;Sepia;_SEPARATOR_;AutoRot;Rot90;Rot180;Rot270;RotCustom;_SEPARATOR_;Flip;Flop
 Encoding=UTF-8
 _X-KDE-Submenu=Kim — Convert and Rotate

--- a/src/kim_publication.desktop.in
+++ b/src/kim_publication.desktop.in
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2005, 2006  Charles Bouveyron <charles.bouveyron@free.fr>
 # Copyright (C) 2025  Tomáš Hnyk <tomashnyk@gmail.com>
+# Copyright (C) 2025  Miguel Useche <migueluseche@skatox.com>
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +19,7 @@
 
 [Desktop Entry]
 Type=Service
-ServiceTypes=KonqPopupMenu/Plugin,image/*
+MimeType=image/*;
 Actions=Rename;SortByDate;SendByMail;_SEPARATOR_;PeleMele;Galery;_SEPARATOR_;Watermark;Border;_SEPARATOR_;Animation;Multiburst;Adjoin;_SEPARATOR_;Manual;License;About;
 Encoding=UTF-8
 _X-KDE-Submenu=Kim — Treatment and publication


### PR DESCRIPTION
Since KDE 5.8 we don't need `ServiceType`, we need to add the filetypes through `MimeType`