### PR TITLE
Add privacy-safe metadata stripping action

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,9 @@ else
        install_log="$install_log""Cannot find encoder <b>libx265</b> for FFmpeg. Encoding video with it will not work. Please install it.<br><br>"
    fi
 fi
+if ! command -v exiftool >/dev/null 2>&1; then
+    install_log="$install_log""Cannot find executable <b>exiftool</b>. Please install it. It is usually in package <b>libimage-exiftool-perl</b> (Debian, Ubuntu etc.), <b>perl-Image-ExifTool</b> (Fedora etc.) or <b>perl-image-exiftool</b>(Arch). Without it, metadata stripping will not work.<br><br>"
+fi
 if ! command -v xdg-email >/dev/null 2>&1; then
     install_log="$install_log""Cannot find executable <b>xdg-email</b>. Please install it. It is usually in package <b>xdg-utils</b>. Without it, sending an image by e-mail will not work.<br><br>."
 fi

--- a/src/bin/kim_stripmeta
+++ b/src/bin/kim_stripmeta
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Strips metadata using ExifTool while preserving the ICC profile (color management)
+#
+# Copyright (C) 2026 codesterribly
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author: codesterribly
+
+SOURCE_TRANSLATION_TTT
+DIR="$1";
+let "nbfiles = ($# / 2)"
+trap 'qdbus $dbusRef close 2>/dev/null' EXIT
+kdialog --title "$(gettext 'Kim')" --yesnocancel "$(gettext 'Do you want to create new files?')" --yes-label "$(gettext 'Create new')" --no-label "$(gettext 'Replace existing')"
+
+case $? in
+    1)  # Replace existing files!
+    dbusRef=$(kdialog --progressbar "$(gettext 'Kim — Initialising metadate stripping')" $nbfiles)
+    qdbus $dbusRef showCancelButton true
+    counter=0
+    for i in "$@";do
+        if [ -f "$i" ];then
+            # test if cancel button has been pushed
+                if [[ "$(qdbus $dbusRef wasCancelled)" == "true" ]] ; then
+                    exit 1
+                fi
+                let "counter +=1"
+                FILE="$i"
+                exiftool -overwrite_original -all= -tagsfromfile "$i" -icc_profile -Orientation -- "$i" #>/dev/null 2>&1
+                qdbus $dbusRef setLabelText "$(gettext 'Kim — Stripping metadata from file: ') `basename "$FILE"`"
+                qdbus $dbusRef org.freedesktop.DBus.Properties.Set org.kde.kdialog.ProgressDialog value $counter
+        fi
+    done;;
+
+    0) # Create new
+    dbusRef=$(kdialog --progressbar "$(gettext 'Kim — Initialising ...')" $nbfiles)
+    # $dbusRef expands to "service path" (two args), do not quote it
+    qdbus $dbusRef showCancelButton true
+    counter=0
+    for i in "$@"; do
+        if [ -f "$i" ]; then
+          # test if cancel button has been pushed
+          if [[ "$(qdbus $dbusRef wasCancelled)" == "true" ]] ; then
+            exit 1
+          fi
+          let "counter += 1"
+          FILE="$i"
+          BASENAME="$(basename "$FILE")"
+          NAME="${BASENAME%.*}"
+          EXT="${BASENAME##*.}"
+          exiftool -all= -tagsfromfile "$i" -icc_profile -Orientation -o "$DIR/${NAME}_stripped.${EXT}" -- "$i" >/dev/null 2>&1
+          qdbus $dbusRef setLabelText "$(gettext 'Kim — Stripping metadata from file: ')$BASENAME"
+          qdbus $dbusRef org.freedesktop.DBus.Properties.Set org.kde.kdialog.ProgressDialog value $counter
+        fi
+    done;;
+
+    2) kdialog --title $(gettext 'Kim') --msgbox "$(gettext 'The action was cancelled by the user!')"
+    exit 1;;
+esac

--- a/src/kim_publication.desktop.in
+++ b/src/kim_publication.desktop.in
@@ -19,7 +19,7 @@
 [Desktop Entry]
 Type=Service
 MimeType=image/*;
-Actions=Rename;SortByDate;SendByMail;_SEPARATOR_;PeleMele;Galery;_SEPARATOR_;Watermark;Border;_SEPARATOR_;Animation;Multiburst;Adjoin;_SEPARATOR_;Manual;License;About;
+Actions=Rename;SortByDate;SendByMail;_SEPARATOR_;PeleMele;Galery;_SEPARATOR_;Watermark;Border;StripMetadata;_SEPARATOR_;Animation;Multiburst;Adjoin;_SEPARATOR_;Manual;License;About;
 Encoding=UTF-8
 _X-KDE-Submenu=Kim — Treatment and publication
 
@@ -67,6 +67,11 @@ Exec=kim_multiburst %u
 _Name=Add a border
 Icon=image
 Exec=kim_treatment border %D %U
+
+[Desktop Action StripMetadata]
+Name=Strip EXIF metadata
+Icon=view-private
+Exec=kim_stripmeta %D %U
 
 [Desktop Action Album]
 _Name=Create a pdf album


### PR DESCRIPTION
Adds new menu option under Treatment and Publication for stripping metadata to protect anonymity. Sets proper picture orientation before it strips it as well.