### PR TITLE
Add Simplified Chinese translation

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -93,7 +93,7 @@ msgstr "是否要创建新文件？"
 #: ../src/bin/kim_sortbydate:31 ../src/bin/kim_treatment:35
 #: ../src/bin/kim_video:98 ../src/bin/kim_webexport:32
 msgid "Create new"
-msgstr "新建文件"
+msgstr "创建新文件"
 
 #: ../src/bin/kim_compress:31 ../src/bin/kim_rename:30 ../src/bin/kim_resize:31
 #: ../src/bin/kim_sortbydate:31 ../src/bin/kim_treatment:35
@@ -111,7 +111,7 @@ msgstr "替换现有文件"
 #: ../src/bin/kim_treatment:38 ../src/bin/kim_treatment:77
 #: ../src/bin/kim_video:101 ../src/bin/kim_video:138
 msgid "Kim — Initialising…"
-msgstr "Kim — 正在初始化..."
+msgstr "Kim — 正在初始化…"
 
 #: ../src/bin/kim_compress:46 ../src/bin/kim_compress:70
 #: ../src/bin/kim_multiburst:53 ../src/bin/kim_webexport:48
@@ -218,7 +218,15 @@ msgstr "Kim — 通过邮件发送："
 
 #: ../src/bin/kim_resizeandsend:32
 msgid "Full size"
-msgstr "原始大小"
+msgstr "完整大小"
+
+#: ../src/bin/kim_resizeandsend:32
+msgid "1600x1600"
+msgstr "1600x1600"
+
+#: ../src/bin/kim_resizeandsend:33
+msgid "1200x1200"
+msgstr "1200x1200"
 
 #: ../src/bin/kim_resizeandsend:32
 msgid "800x800 px"
@@ -232,6 +240,14 @@ msgstr "600x600 像素"
 msgid "300x300 px"
 msgstr "300x300 像素"
 
+#: ../src/bin/kim_resizeandsend:37
+msgid "Custom size..."
+msgstr "自定义大小..."
+
+#: ../src/bin/kim_resizeandsend:49
+msgid "Kim — Copying files to temporary directory: "
+msgstr "Kim — 正在复制文件到临时目录："
+
 #: ../src/bin/kim_resizeandsend:49
 msgid "Kim — Resizing and compressing file: "
 msgstr "Kim — 正在调整并压缩文件："
@@ -240,6 +256,22 @@ msgstr "Kim — 正在调整并压缩文件："
 #: ../src/bin/kim_resizeandsend:74
 msgid "Kim — Send by mail: you can write your message!"
 msgstr "Kim — 通过邮件发送：你可以开始撰写邮件了！"
+
+#: ../src/bin/kim_resizeandsend:93
+msgid ""
+"Kim — Send by mail: you can write your message, hopefully your mail client "
+"supports adding attachments via xdg-email!"
+msgstr ""
+"Kim — 通过邮件发送：你可以开始撰写邮件了，希望你的邮件客户端"
+"支持通过 xdg-email 添加附件！"
+
+#: ../src/bin/kim_stripmeta:30
+msgid "Kim — Initialising metadate stripping"
+msgstr "Kim — 正在初始化元数据清理"
+
+#: ../src/bin/kim_stripmeta:42 ../src/bin/kim_stripmeta:64
+msgid "Kim — Stripping metadata from file: "
+msgstr "Kim — 正在移除文件元数据："
 
 #: ../src/bin/kim_treatment:32
 msgid "Choose your annotation:"
@@ -280,39 +312,39 @@ msgstr "Kim — 压缩和调整大小"
 
 #: ../src/kim_compressandresize.desktop.in.h:3
 msgid "Compress at 10 %"
-msgstr "压缩到 10 %"
+msgstr "以 10 % 质量压缩"
 
 #: ../src/kim_compressandresize.desktop.in.h:5
 msgid "Compress at 20 %"
-msgstr "压缩到 20 %"
+msgstr "以 20 % 质量压缩"
 
 #: ../src/kim_compressandresize.desktop.in.h:7
 msgid "Compress at 30 %"
-msgstr "压缩到 30 %"
+msgstr "以 30 % 质量压缩"
 
 #: ../src/kim_compressandresize.desktop.in.h:9
 msgid "Compress at 40 %"
-msgstr "压缩到 40 %"
+msgstr "以 40 % 质量压缩"
 
 #: ../src/kim_compressandresize.desktop.in.h:11
 msgid "Compress at 50 %"
-msgstr "压缩到 50 %"
+msgstr "以 50 % 质量压缩"
 
 #: ../src/kim_compressandresize.desktop.in.h:13
 msgid "Compress at 60 %"
-msgstr "压缩到 60 %"
+msgstr "以 60 % 质量压缩"
 
 #: ../src/kim_compressandresize.desktop.in.h:15
 msgid "Compress at 70 %"
-msgstr "压缩到 70 %"
+msgstr "以 70 % 质量压缩"
 
 #: ../src/kim_compressandresize.desktop.in.h:17
 msgid "Compress at 80 %"
-msgstr "压缩到 80 %"
+msgstr "以 80 % 质量压缩"
 
 #: ../src/kim_compressandresize.desktop.in.h:19
 msgid "Compress at 90 %"
-msgstr "压缩到 90 %"
+msgstr "以 90 % 质量压缩"
 
 #: ../src/kim_compressandresize.desktop.in.h:20
 msgid "Compress Custom..."
@@ -381,6 +413,10 @@ msgstr "网页导出：800x800，质量 75 %"
 #: ../src/kim_compressandresize.desktop.in.h:40
 msgid "WebExport: 1024x1024 at 75 %"
 msgstr "网页导出：1024x1024，质量 75 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:34
+msgid "WebExport: 1600x1600 at 75 %"
+msgstr "网页导出：1600x1600，质量 75 %"
 
 #: ../src/kim_compressandresizevideo.desktop.in.h:2
 msgid "Transcode video to 1280x720, good quality, libx265"
@@ -522,6 +558,14 @@ msgid "Convert to PDF"
 msgstr "转换为 PDF"
 
 #: ../src/kim_convertandrotate.desktop.in.h:8
+msgid "Convert to WebP"
+msgstr "转换为 WebP"
+
+#: ../src/kim_convertandrotate.desktop.in.h:9
+msgid "Convert to AVIF"
+msgstr "转换为 AVIF"
+
+#: ../src/kim_convertandrotate.desktop.in.h:8
 msgid "Convert custom ..."
 msgstr "自定义转换..."
 
@@ -587,7 +631,7 @@ msgstr "重命名图片"
 
 #: ../src/kim_publication.desktop.in.h:7
 msgid "Create a multi-files Tiff image"
-msgstr "创建多文件 TIFF 图片"
+msgstr "创建多页 TIFF 图像"
 
 #: ../src/kim_publication.desktop.in.h:8
 msgid "Create a gif animation"
@@ -600,6 +644,10 @@ msgstr "将连拍图片转换为 GIF 动画"
 #: ../src/kim_publication.desktop.in.h:10
 msgid "Add a border"
 msgstr "添加边框"
+
+#: ../src/kim_publication.desktop.in.h:11
+msgid "Strip EXIF metadata"
+msgstr "移除 EXIF 元数据"
 
 #: ../src/kim_publication.desktop.in.h:11
 msgid "Create a pdf album"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,7 +1,7 @@
 # Chinese (Simplified) translations for KIM 6 — Kde Image Menu 6 package.
 # Copyright (C) 2026 THE KIM 6 — Kde Image Menu 6'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the KIM 6 — Kde Image Menu 6 package.
-# zjut-gwb, 2026.
+# asikeida <asikeida@gmail.com>, 2026.
 #
 msgid ""
 msgstr ""
@@ -9,12 +9,13 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/KIM-6/kim6/issues\n"
 "POT-Creation-Date: 2026-01-14 01:15+0100\n"
 "PO-Revision-Date: 2026-08-30 00:00+0800\n"
-"Last-Translator: zjut-gwb\n"
+"Last-Translator: asikeida <asikeida@gmail.com>\n"
 "Language-Team: Chinese (Simplified)\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: ../src/bin/kim_album:25 ../src/bin/kim_print:29
 msgid "Kim — Select album type:"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,0 +1,609 @@
+# Chinese (Simplified) translations for KIM 6 — Kde Image Menu 6 package.
+# Copyright (C) 2026 THE KIM 6 — Kde Image Menu 6'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the KIM 6 — Kde Image Menu 6 package.
+# zjut-gwb, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: KIM 6 — Kde Image Menu 6 2.1\n"
+"Report-Msgid-Bugs-To: https://github.com/KIM-6/kim6/issues\n"
+"POT-Creation-Date: 2026-01-14 01:15+0100\n"
+"PO-Revision-Date: 2026-08-30 00:00+0800\n"
+"Last-Translator: zjut-gwb\n"
+"Language-Team: Chinese (Simplified)\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../src/bin/kim_album:25 ../src/bin/kim_print:29
+msgid "Kim — Select album type:"
+msgstr "Kim — 选择相册类型："
+
+#: ../src/bin/kim_album:25
+msgid "1x1 portrait album"
+msgstr "1x1 纵向相册"
+
+#: ../src/bin/kim_album:25
+msgid "1x1 landscape album"
+msgstr "1x1 横向相册"
+
+#: ../src/bin/kim_album:25
+msgid "1x2 landscape album"
+msgstr "1x2 横向相册"
+
+#: ../src/bin/kim_album:25
+msgid "2x1 portrait album"
+msgstr "2x1 纵向相册"
+
+#: ../src/bin/kim_album:25
+msgid "2x2 landscape album"
+msgstr "2x2 横向相册"
+
+#: ../src/bin/kim_album:25 ../src/bin/kim_print:29
+msgid "3x2 portrait album"
+msgstr "3x2 纵向相册"
+
+#: ../src/bin/kim_album:25
+msgid "3x4 landscape album"
+msgstr "3x4 横向相册"
+
+#: ../src/bin/kim_album:25
+msgid "4x4 landscape album"
+msgstr "4x4 横向相册"
+
+#: ../src/bin/kim_album:31
+msgid "Kim — Creating miniatures ..."
+msgstr "Kim — 正在创建缩略图..."
+
+#: ../src/bin/kim_album:34 ../src/bin/kim_album:39 ../src/bin/kim_album:45
+#: ../src/bin/kim_album:50 ../src/bin/kim_album:55 ../src/bin/kim_album:60
+#: ../src/bin/kim_album:65 ../src/bin/kim_album:70 ../src/bin/kim_print:55
+#: ../src/bin/kim_print:61 ../src/bin/kim_print:66 ../src/bin/kim_print:71
+#: ../src/bin/kim_print:76 ../src/bin/kim_print:81 ../src/bin/kim_print:86
+msgid "Kim — Creating album ..."
+msgstr "Kim — 正在创建相册..."
+
+#: ../src/bin/kim_album:74 ../src/bin/kim_print:90
+msgid "Kim — Unrecognized option! "
+msgstr "Kim — 无法识别的选项！"
+
+#: ../src/bin/kim_album:77 ../src/bin/kim_print:93
+msgid "Kim — Deleting miniatures ..."
+msgstr "Kim — 正在删除缩略图..."
+
+#: ../src/bin/kim_compress:31 ../src/bin/kim_compress:76
+#: ../src/bin/kim_rename:30 ../src/bin/kim_rename:88 ../src/bin/kim_resize:31
+#: ../src/bin/kim_resize:77 ../src/bin/kim_sortbydate:31
+#: ../src/bin/kim_sortbydate:106 ../src/bin/kim_treatment:35
+#: ../src/bin/kim_treatment:115 ../src/bin/kim_video:98
+#: ../src/bin/kim_video:168 ../src/bin/kim_webexport:32
+#: ../src/bin/kim_webexport:77
+msgid "Kim"
+msgstr "Kim"
+
+#: ../src/bin/kim_compress:31 ../src/bin/kim_rename:30 ../src/bin/kim_resize:31
+#: ../src/bin/kim_sortbydate:31 ../src/bin/kim_treatment:35
+#: ../src/bin/kim_video:98 ../src/bin/kim_webexport:32
+msgid "Do you want to create new files?"
+msgstr "是否要创建新文件？"
+
+#: ../src/bin/kim_compress:31 ../src/bin/kim_rename:30 ../src/bin/kim_resize:31
+#: ../src/bin/kim_sortbydate:31 ../src/bin/kim_treatment:35
+#: ../src/bin/kim_video:98 ../src/bin/kim_webexport:32
+msgid "Create new"
+msgstr "新建文件"
+
+#: ../src/bin/kim_compress:31 ../src/bin/kim_rename:30 ../src/bin/kim_resize:31
+#: ../src/bin/kim_sortbydate:31 ../src/bin/kim_treatment:35
+#: ../src/bin/kim_video:98 ../src/bin/kim_webexport:32
+msgid "Replace existing"
+msgstr "替换现有文件"
+
+#: ../src/bin/kim_compress:34 ../src/bin/kim_compress:54
+#: ../src/bin/kim_convert:31 ../src/bin/kim_flipflop:30
+#: ../src/bin/kim_galery:39 ../src/bin/kim_pelemele:37 ../src/bin/kim_print:31
+#: ../src/bin/kim_rename:33 ../src/bin/kim_rename:61 ../src/bin/kim_resize:34
+#: ../src/bin/kim_resize:55 ../src/bin/kim_resizeandsend:35
+#: ../src/bin/kim_rotate:30 ../src/bin/kim_rotatewithexif:30
+#: ../src/bin/kim_sortbydate:35 ../src/bin/kim_sortbydate:71
+#: ../src/bin/kim_treatment:38 ../src/bin/kim_treatment:77
+#: ../src/bin/kim_video:101 ../src/bin/kim_video:138
+msgid "Kim — Initialising…"
+msgstr "Kim — 正在初始化..."
+
+#: ../src/bin/kim_compress:46 ../src/bin/kim_compress:70
+#: ../src/bin/kim_multiburst:53 ../src/bin/kim_webexport:48
+#: ../src/bin/kim_webexport:71
+msgid "Kim — Compressing file: "
+msgstr "Kim — 正在压缩文件："
+
+#: ../src/bin/kim_compress:76 ../src/bin/kim_rename:88 ../src/bin/kim_resize:77
+#: ../src/bin/kim_sortbydate:106 ../src/bin/kim_treatment:115
+#: ../src/bin/kim_video:168 ../src/bin/kim_webexport:77
+msgid "The action was cancelled by the user!"
+msgstr "操作已被用户取消！"
+
+#: ../src/bin/kim_convert:44
+msgid "Kim — Converting file:"
+msgstr "Kim — 正在转换文件："
+
+#: ../src/bin/kim_flipflop:43 ../src/bin/kim_rotate:47
+#: ../src/bin/kim_rotatewithexif:44
+msgid "Kim — Rotating file: "
+msgstr "Kim — 正在旋转文件："
+
+#: ../src/bin/kim_galery:29
+msgid "Kim — Title:"
+msgstr "Kim — 标题："
+
+#: ../src/bin/kim_galery:29
+msgid "My title ..."
+msgstr "我的标题..."
+
+#: ../src/bin/kim_galery:30
+msgid "Kim — Author:"
+msgstr "Kim — 作者："
+
+#: ../src/bin/kim_galery:34
+msgid "Kim — Number of columns:"
+msgstr "Kim — 列数："
+
+#: ../src/bin/kim_galery:79 ../src/bin/kim_treatment:50
+#: ../src/bin/kim_treatment:89
+msgid "Kim — Treatment of file: "
+msgstr "Kim — 正在处理文件："
+
+#: ../src/bin/kim_pelemele:29
+msgid "Size of small images:"
+msgstr "小图片大小："
+
+#: ../src/bin/kim_pelemele:30
+msgid "Number of rows and columns:"
+msgstr "行数和列数："
+
+#: ../src/bin/kim_pelemele:31
+msgid "Overlaping ratio in percent:"
+msgstr "重叠比例（百分比）："
+
+#: ../src/bin/kim_pelemele:32
+msgid "Background color:"
+msgstr "背景颜色："
+
+#: ../src/bin/kim_pelemele:63 ../src/bin/kim_print:46
+msgid "Kim — resizing file: "
+msgstr "Kim — 正在调整文件大小："
+
+#: ../src/bin/kim_print:29
+msgid "9x13 cm: 2x2 images, landscape"
+msgstr "9x13 cm：2x2 张图片，横向"
+
+#: ../src/bin/kim_print:29
+msgid "10x15 cm: 1x2 images, portrait"
+msgstr "10x15 cm：1x2 张图片，纵向"
+
+#: ../src/bin/kim_print:29
+msgid "11.5x15 cm: 1x2 images, portrait"
+msgstr "11.5x15 cm：1x2 张图片，纵向"
+
+#: ../src/bin/kim_print:29
+msgid "13x18 cm: 1x2 images, portrait"
+msgstr "13x18 cm：1x2 张图片，纵向"
+
+#: ../src/bin/kim_print:29
+msgid "20x25 cm: 1 image, landscape"
+msgstr "20x25 cm：1 张图片，横向"
+
+#: ../src/bin/kim_print:29
+msgid "Thumbnails: 4x5 images, portrait"
+msgstr "缩略图：4x5 张图片，纵向"
+
+#: ../src/bin/kim_rename:36 ../src/bin/kim_rename:64
+msgid "Choose the new name of images:"
+msgstr "选择图片的新名称："
+
+#: ../src/bin/kim_rename:54 ../src/bin/kim_rename:82
+#: ../src/bin/kim_sortbydate:64 ../src/bin/kim_sortbydate:100
+msgid "Kim — Renaming file: "
+msgstr "Kim — 正在重命名文件："
+
+#: ../src/bin/kim_resize:47 ../src/bin/kim_resize:71
+msgid "Kim — Resizing file: "
+msgstr "Kim — 正在调整文件大小："
+
+#: ../src/bin/kim_resizeandsend:32
+msgid "Kim — Send by mail:"
+msgstr "Kim — 通过邮件发送："
+
+#: ../src/bin/kim_resizeandsend:32
+msgid "Full size"
+msgstr "原始大小"
+
+#: ../src/bin/kim_resizeandsend:32
+msgid "800x800 px"
+msgstr "800x800 像素"
+
+#: ../src/bin/kim_resizeandsend:32
+msgid "600x600 px"
+msgstr "600x600 像素"
+
+#: ../src/bin/kim_resizeandsend:32
+msgid "300x300 px"
+msgstr "300x300 像素"
+
+#: ../src/bin/kim_resizeandsend:49
+msgid "Kim — Resizing and compressing file: "
+msgstr "Kim — 正在调整并压缩文件："
+
+#: ../src/bin/kim_resizeandsend:64 ../src/bin/kim_resizeandsend:69
+#: ../src/bin/kim_resizeandsend:74
+msgid "Kim — Send by mail: you can write your message!"
+msgstr "Kim — 通过邮件发送：你可以开始撰写邮件了！"
+
+#: ../src/bin/kim_treatment:32
+msgid "Choose your annotation:"
+msgstr "选择你的注释："
+
+#: ../src/bin/kim_treatment:32
+msgid "My annotation"
+msgstr "我的注释"
+
+#: ../src/bin/kim_treatment:33
+msgid "Kim — Select border color:"
+msgstr "Kim — 选择边框颜色："
+
+#: ../src/bin/kim_treatment:33
+msgid "white"
+msgstr "白色"
+
+#: ../src/bin/kim_treatment:33
+msgid "black"
+msgstr "黑色"
+
+#: ../src/bin/kim_video:87
+msgid "Kim —  Transcoding video: "
+msgstr "Kim — 正在转码视频："
+
+#: ../src/bin/kim_video:113
+msgid "Kim — "
+msgstr "Kim — "
+
+#: ../src/bin/kim_video:162
+msgid "Kim — Transcoding video"
+msgstr "Kim — 正在转码视频"
+
+#: ../src/kim_compressandresize.desktop.in.h:1
+#: ../src/kim_compressandresizevideo.desktop.in.h:1
+msgid "Kim — Compress and Resize"
+msgstr "Kim — 压缩和调整大小"
+
+#: ../src/kim_compressandresize.desktop.in.h:3
+msgid "Compress at 10 %"
+msgstr "压缩到 10 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:5
+msgid "Compress at 20 %"
+msgstr "压缩到 20 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:7
+msgid "Compress at 30 %"
+msgstr "压缩到 30 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:9
+msgid "Compress at 40 %"
+msgstr "压缩到 40 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:11
+msgid "Compress at 50 %"
+msgstr "压缩到 50 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:13
+msgid "Compress at 60 %"
+msgstr "压缩到 60 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:15
+msgid "Compress at 70 %"
+msgstr "压缩到 70 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:17
+msgid "Compress at 80 %"
+msgstr "压缩到 80 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:19
+msgid "Compress at 90 %"
+msgstr "压缩到 90 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:20
+msgid "Compress Custom..."
+msgstr "自定义压缩..."
+
+#: ../src/kim_compressandresize.desktop.in.h:21
+msgid "Resize (300x300 pixels)"
+msgstr "调整大小（300x300 像素）"
+
+#: ../src/kim_compressandresize.desktop.in.h:22
+msgid "Resize (600x600 pixels)"
+msgstr "调整大小（600x600 像素）"
+
+#: ../src/kim_compressandresize.desktop.in.h:23
+msgid "Resize (800x800 pixels)"
+msgstr "调整大小（800x800 像素）"
+
+#: ../src/kim_compressandresize.desktop.in.h:24
+msgid "Resize (1024x1024 pixels)"
+msgstr "调整大小（1024x1024 像素）"
+
+#: ../src/kim_compressandresize.desktop.in.h:25
+msgid "Resize (1280x1280 pixels)"
+msgstr "调整大小（1280x1280 像素）"
+
+#: ../src/kim_compressandresize.desktop.in.h:26
+msgid "Resize (1400x1400 pixels)"
+msgstr "调整大小（1400x1400 像素）"
+
+#: ../src/kim_compressandresize.desktop.in.h:27
+msgid "Resize (1600x1600 pixels)"
+msgstr "调整大小（1600x1600 像素）"
+
+#: ../src/kim_compressandresize.desktop.in.h:28
+msgid "Resize (1920x1920 pixels)"
+msgstr "调整大小（1920x1920 像素）"
+
+#: ../src/kim_compressandresize.desktop.in.h:29
+msgid "Resize (2560x2560 pixels)"
+msgstr "调整大小（2560x2560 像素）"
+
+#: ../src/kim_compressandresize.desktop.in.h:30
+msgid "Resize (3440x3440 pixels)"
+msgstr "调整大小（3440x3440 像素）"
+
+#: ../src/kim_compressandresize.desktop.in.h:31
+msgid "Resize (3840x3840 pixels)"
+msgstr "调整大小（3840x3840 像素）"
+
+#: ../src/kim_compressandresize.desktop.in.h:32
+msgid "Resize Custom..."
+msgstr "自定义大小..."
+
+#: ../src/kim_compressandresize.desktop.in.h:34
+msgid "WebThumbnail: 128x128 at 75 %"
+msgstr "网页缩略图：128x128，质量 75 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:36
+msgid "WebExport: 600x600 at 75 %"
+msgstr "网页导出：600x600，质量 75 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:38
+msgid "WebExport: 800x800 at 75 %"
+msgstr "网页导出：800x800，质量 75 %"
+
+#: ../src/kim_compressandresize.desktop.in.h:40
+msgid "WebExport: 1024x1024 at 75 %"
+msgstr "网页导出：1024x1024，质量 75 %"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:2
+msgid "Transcode video to 1280x720, good quality, libx265"
+msgstr "将视频转码为 1280x720，高质量，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:3
+msgid "Transcode video to 1280x720, medium quality, libx265"
+msgstr "将视频转码为 1280x720，中等质量，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:4
+msgid "Transcode video to 1280x720, bad quality, libx265"
+msgstr "将视频转码为 1280x720，低质量，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:5
+msgid "Transcode video to 1280x720, good quality, libx264"
+msgstr "将视频转码为 1280x720，高质量，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:6
+msgid "Transcode video to 1280x720, medium quality, libx264"
+msgstr "将视频转码为 1280x720，中等质量，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:7
+msgid "Transcode video to 1280x720, bad quality, libx264"
+msgstr "将视频转码为 1280x720，低质量，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:8
+msgid "Transcode video to 1920x1080, good quality, libx265"
+msgstr "将视频转码为 1920x1080，高质量，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:9
+msgid "Transcode video to 1920x1080, medium quality, libx265"
+msgstr "将视频转码为 1920x1080，中等质量，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:10
+msgid "Transcode video to 1920x1080, bad quality, libx265"
+msgstr "将视频转码为 1920x1080，低质量，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:11
+msgid "Transcode video to 1920x1080, good quality, libx264"
+msgstr "将视频转码为 1920x1080，高质量，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:12
+msgid "Transcode video to 1920x1080, medium quality, libx264"
+msgstr "将视频转码为 1920x1080，中等质量，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:13
+msgid "Transcode video to 1920x1080, bad quality, libx264"
+msgstr "将视频转码为 1920x1080，低质量，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:14
+msgid "Transcode video to 1280x720, good quality, mp4, libx265"
+msgstr "将视频转码为 1280x720，高质量，MP4，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:15
+msgid "Transcode video to 1280x720, medium quality, mp4, libx265"
+msgstr "将视频转码为 1280x720，中等质量，MP4，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:16
+msgid "Transcode video to 1280x720, bad quality, mp4, libx265"
+msgstr "将视频转码为 1280x720，低质量，MP4，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:17
+msgid "Transcode video to 1280x720, good quality, mp4, libx264"
+msgstr "将视频转码为 1280x720，高质量，MP4，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:18
+msgid "Transcode video to 1280x720, medium quality, mp4, libx264"
+msgstr "将视频转码为 1280x720，中等质量，MP4，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:19
+msgid "Transcode video to 1280x720, bad quality, mp4, libx264"
+msgstr "将视频转码为 1280x720，低质量，MP4，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:20
+msgid "Transcode video to 1920x1080, good quality, mp4, libx265"
+msgstr "将视频转码为 1920x1080，高质量，MP4，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:21
+msgid "Transcode video to 1920x1080, medium quality, mp4, libx265"
+msgstr "将视频转码为 1920x1080，中等质量，MP4，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:22
+msgid "Transcode video to 1920x1080, bad quality, mp4, libx265"
+msgstr "将视频转码为 1920x1080，低质量，MP4，libx265"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:23
+msgid "Transcode video to 1920x1080, good quality, mp4, libx264"
+msgstr "将视频转码为 1920x1080，高质量，MP4，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:24
+msgid "Transcode video to 1920x1080, medium quality, mp4, libx264"
+msgstr "将视频转码为 1920x1080，中等质量，MP4，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:25
+msgid "Transcode video to 1920x1080, bad quality, mp4, libx264"
+msgstr "将视频转码为 1920x1080，低质量，MP4，libx264"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:26
+#: ../src/kim_publication.desktop.in.h:13
+msgid "KIM 6 Manual"
+msgstr "KIM 6 手册"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:27
+#: ../src/kim_publication.desktop.in.h:14
+msgid "License"
+msgstr "许可证"
+
+#: ../src/kim_compressandresizevideo.desktop.in.h:28
+#: ../src/kim_publication.desktop.in.h:15
+msgid "About Kim"
+msgstr "关于 Kim"
+
+#: ../src/kim_convertandrotate.desktop.in.h:1
+msgid "Kim — Convert and Rotate"
+msgstr "Kim — 转换和旋转"
+
+#: ../src/kim_convertandrotate.desktop.in.h:2
+msgid "Convert to JPEG"
+msgstr "转换为 JPEG"
+
+#: ../src/kim_convertandrotate.desktop.in.h:3
+msgid "Convert to PNG"
+msgstr "转换为 PNG"
+
+#: ../src/kim_convertandrotate.desktop.in.h:4
+msgid "Convert to GIF"
+msgstr "转换为 GIF"
+
+#: ../src/kim_convertandrotate.desktop.in.h:5
+msgid "Convert to BMP (bitmap)"
+msgstr "转换为 BMP（位图）"
+
+#: ../src/kim_convertandrotate.desktop.in.h:6
+msgid "Convert to TIFF"
+msgstr "转换为 TIFF"
+
+#: ../src/kim_convertandrotate.desktop.in.h:7
+msgid "Convert to PDF"
+msgstr "转换为 PDF"
+
+#: ../src/kim_convertandrotate.desktop.in.h:8
+msgid "Convert custom ..."
+msgstr "自定义转换..."
+
+#: ../src/kim_convertandrotate.desktop.in.h:9
+msgid "Convert to graysale"
+msgstr "转换为灰度"
+
+#: ../src/kim_convertandrotate.desktop.in.h:10
+msgid "Convert in sepia tone"
+msgstr "转换为棕褐色调"
+
+#: ../src/kim_convertandrotate.desktop.in.h:11
+msgid "Auto-rotate with EXIF"
+msgstr "根据 EXIF 自动旋转"
+
+#: ../src/kim_convertandrotate.desktop.in.h:12
+msgid "Rotate (90°)"
+msgstr "旋转（90°）"
+
+#: ../src/kim_convertandrotate.desktop.in.h:13
+msgid "Rotate (180°)"
+msgstr "旋转（180°）"
+
+#: ../src/kim_convertandrotate.desktop.in.h:14
+msgid "Rotate (270°)"
+msgstr "旋转（270°）"
+
+#: ../src/kim_convertandrotate.desktop.in.h:15
+msgid "Rotate custom..."
+msgstr "自定义旋转..."
+
+#: ../src/kim_convertandrotate.desktop.in.h:16
+msgid "Flip verticaly"
+msgstr "垂直翻转"
+
+#: ../src/kim_convertandrotate.desktop.in.h:17
+msgid "Flip horizontaly"
+msgstr "水平翻转"
+
+#: ../src/kim_publication.desktop.in.h:1
+msgid "Kim — Treatment and publication"
+msgstr "Kim — 处理和发布"
+
+#: ../src/kim_publication.desktop.in.h:2
+msgid "Create a html gallery"
+msgstr "创建 HTML 图库"
+
+#: ../src/kim_publication.desktop.in.h:3
+msgid "Create a photo montage"
+msgstr "创建照片拼贴"
+
+#: ../src/kim_publication.desktop.in.h:4
+msgid "Send by mail"
+msgstr "通过邮件发送"
+
+#: ../src/kim_publication.desktop.in.h:5
+msgid "Sort by date"
+msgstr "按日期排序"
+
+#: ../src/kim_publication.desktop.in.h:6
+msgid "Rename images"
+msgstr "重命名图片"
+
+#: ../src/kim_publication.desktop.in.h:7
+msgid "Create a multi-files Tiff image"
+msgstr "创建多文件 TIFF 图片"
+
+#: ../src/kim_publication.desktop.in.h:8
+msgid "Create a gif animation"
+msgstr "创建 GIF 动画"
+
+#: ../src/kim_publication.desktop.in.h:9
+msgid "Multiburst image to gif animation"
+msgstr "将连拍图片转换为 GIF 动画"
+
+#: ../src/kim_publication.desktop.in.h:10
+msgid "Add a border"
+msgstr "添加边框"
+
+#: ../src/kim_publication.desktop.in.h:11
+msgid "Create a pdf album"
+msgstr "创建 PDF 相册"
+
+#: ../src/kim_publication.desktop.in.h:12
+msgid "Add text annotation"
+msgstr "添加文字注释"

--- a/src/kim_convertandrotate.desktop.in
+++ b/src/kim_convertandrotate.desktop.in
@@ -54,12 +54,12 @@ Icon=application-pdf
 Exec=kim_convert pdf %U
 
 [Desktop Action WEBP]
-Name=Convert to WebP
+_Name=Convert to WebP
 Icon=image
 Exec=kim_convert webp %U
 
 [Desktop Action AVIF]
-Name=Convert to AVIF
+_Name=Convert to AVIF
 Icon=image
 Exec=kim_convert avif %U
 

--- a/src/kim_publication.desktop.in
+++ b/src/kim_publication.desktop.in
@@ -69,7 +69,7 @@ Icon=image
 Exec=kim_treatment border %D %U
 
 [Desktop Action StripMetadata]
-Name=Strip EXIF metadata
+_Name=Strip EXIF metadata
 Icon=view-private
 Exec=kim_stripmeta %D %U
 


### PR DESCRIPTION
Adds a zh_CN gettext translation for KIM6.

Also marks a few existing desktop menu items as translatable so the Simplified Chinese translation covers WebP, AVIF, and EXIF metadata stripping entries.

为 KIM6 添加 zh_CN gettext 翻译。

同时将少量现有桌面菜单项标记为可翻译，使简体中文翻译能够覆盖 WebP、AVIF 和移除 EXIF 元数据等菜单项。

Validation performed:
- msgfmt --check --statistics po/zh_CN.po
- msgcmp --use-untranslated po/zh_CN.po po/kim6.pot
- intltool-merge --desktop-style po src/kim_compressandresize.desktop.in /tmp/opencode/kim_compressandresize.desktop
- intltool-merge --desktop-style po src/kim_convertandrotate.desktop.in /tmp/opencode/kim_convertandrotate.desktop
- intltool-merge --desktop-style po src/kim_publication.desktop.in /tmp/opencode/kim_publication.desktop
- intltool-merge --desktop-style po src/kim_compressandresizevideo.desktop.in /tmp/opencode/kim_compressandresizevideo.desktop

已执行验证：
- msgfmt --check --statistics po/zh_CN.po
- msgcmp --use-untranslated po/zh_CN.po po/kim6.pot
- intltool-merge --desktop-style po src/kim_compressandresize.desktop.in /tmp/opencode/kim_compressandresize.desktop
- intltool-merge --desktop-style po src/kim_convertandrotate.desktop.in /tmp/opencode/kim_convertandrotate.desktop
- intltool-merge --desktop-style po src/kim_publication.desktop.in /tmp/opencode/kim_publication.desktop
- intltool-merge --desktop-style po src/kim_compressandresizevideo.desktop.in /tmp/opencode/kim_compressandresizevideo.desktop
